### PR TITLE
http-files generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ wheels/
 *.egg
 MANIFEST
 pip-selfcheck.json
+.mr.developer.cfg
+src/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/README.rst
+++ b/README.rst
@@ -60,3 +60,27 @@ For translation into *uk* (2 letter ISO language code), you have to follow the s
 
       ../../bin/sphinx-intl build
 
+
+-------------------------------------------------
+
+Alternative install (+http-files generation)::
+
+  ./bootstrap.sh
+  ./bin/buildout -c develop.cfg
+
+
+To update http-files::
+
+    1. Checkout sources to your feature-branch
+
+        ./checkout_src.sh feature/my-branch
+
+    2. Run tests
+
+        ./run_docs_tests.sh
+
+    3. Copy files to sources dir
+
+        ./copy_http_files.sh
+
+Each from the steps above can be done manually.

--- a/checkout_src.sh
+++ b/checkout_src.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if [ -z "$1" ]
+then
+    echo "No branch supplied (Example: './checkout_src.sh feature/mind-blow')"
+    exit
+fi
+
+cd src
+for d in */ ; do
+    cd "$d"
+    git checkout "$1" && echo "Success $d" || echo "Fail $d"
+    cd ..
+done

--- a/copy_http_files.sh
+++ b/copy_http_files.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+TARGET_DIR='docs/source/http'
+SOURCE='src/openprocurement.tender.belowthreshold/docs/source'
+rm -rf "$TARGET_DIR"
+mkdir -p "$TARGET_DIR"
+cp -R "$SOURCE/tutorial" "$TARGET_DIR"
+cp -R "$SOURCE/qualification" "$TARGET_DIR"
+cp -R "$SOURCE/complaints" "$TARGET_DIR"
+
+
+SOURCE="src/openprocurement.contracting.api/docs/source/tutorial/."
+TARGET_DIR='docs/source/contracting/http'
+rm -rf "$TARGET_DIR"
+mkdir -p "$TARGET_DIR"
+cp -R "$SOURCE" "$TARGET_DIR"
+
+
+SOURCE="src/openprocurement.tender.openuadefense/docs/source/tutorial/."
+TARGET_DIR='docs/source/defense/http'
+rm -rf "$TARGET_DIR"
+mkdir -p "$TARGET_DIR"
+cp -R "$SOURCE" "$TARGET_DIR"
+
+
+SOURCE="src/openprocurement.tender.limited/docs/source"
+TARGET_DIR='docs/source/limited/http'
+rm -rf "$TARGET_DIR"
+mkdir -p "$TARGET_DIR"
+cp -R "$SOURCE/tutorial" "$TARGET_DIR"
+cp -R "$SOURCE/multiple_lots_tutorial" "$TARGET_DIR"
+
+
+SOURCE="src/openprocurement.tender.openeu/docs/source"
+TARGET_DIR='docs/source/openeu/http'
+rm -rf "$TARGET_DIR"
+mkdir -p "$TARGET_DIR"
+cp -R "$SOURCE/tutorial" "$TARGET_DIR"
+cp -R "$SOURCE/multiple_lots_tutorial" "$TARGET_DIR"
+
+
+SOURCES="src/openprocurement.tender.openua/docs/source/tutorial/."
+TARGET_DIR='docs/source/openua/http'
+rm -rf "$TARGET_DIR"
+mkdir -p "$TARGET_DIR"
+cp -R "$SOURCES" "$TARGET_DIR"

--- a/develop.cfg
+++ b/develop.cfg
@@ -1,0 +1,52 @@
+[buildout]
+extends = buildout.cfg
+extensions = mr.developer
+auto-checkout = *
+always-checkout = force
+parts += scripts
+
+eggs =
+    openprocurement.api
+    openprocurement.tender.core
+    openprocurement.tender.belowthreshold
+    openprocurement.tender.openua
+    openprocurement.tender.openeu
+    openprocurement.tender.limited
+    openprocurement.tender.openuadefense
+    openprocurement.tender.competitivedialogue
+    openprocurement.tender.esco
+    openprocurement.contracting.api
+    openprocurement.planning.api
+    WebTest
+    cornice
+    nose
+
+[remotes]
+gh = git https://github.com/ProzorroUKR/
+ghop = git https://github.com/ProzorroUKR/openprocurement
+branch = master
+
+[sources]
+openprocurement.api = ${remotes:ghop}.api.git branch=${remotes:branch}
+openprocurement.planning.api = ${remotes:ghop}.planning.api.git branch=${remotes:branch}
+openprocurement.contracting.api = ${remotes:ghop}.contracting.api.git branch=${remotes:branch}
+openprocurement.tender.core = ${remotes:ghop}.tender.core.git branch=${remotes:branch}
+openprocurement.tender.belowthreshold = ${remotes:ghop}.tender.belowthreshold.git branch=${remotes:branch}
+openprocurement.tender.limited = ${remotes:ghop}.tender.limited.git branch=${remotes:branch}
+openprocurement.tender.openua = ${remotes:ghop}.tender.openua.git branch=${remotes:branch}
+openprocurement.tender.openeu = ${remotes:ghop}.tender.openeu.git branch=${remotes:branch}
+openprocurement.tender.openuadefense = ${remotes:ghop}.tender.openuadefense.git branch=${remotes:branch}
+openprocurement.tender.competitivedialogue = ${remotes:ghop}.tender.competitivedialogue.git branch=${remotes:branch}
+openprocurement.tender.esco = ${remotes:ghop}.tender.esco.git branch=${remotes:branch}
+esculator = ${remotes:gh}esculator.git branch=${remotes:branch}
+barbecue = ${remotes:gh}barbecue rev=0.2
+cornice = ${remotes:gh}cornice rev=1.2.0.dev0
+
+
+[scripts]
+recipe = zc.recipe.egg
+eggs = ${buildout:eggs}
+scripts = nosetests
+
+[versions]
+schematics = 1.1.1

--- a/run_docs_tests.sh
+++ b/run_docs_tests.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+cd src
+for d in */ ; do
+    cd "$d"
+    if [ -f "docs.py" ]
+    then
+        echo "Start docs.py tests in $d"
+        ../../bin/nosetests docs.py
+    fi
+    cd ..
+done


### PR DESCRIPTION
Альтернатива генерации http -файлов в трависе и пуше их автомматом в эту репу. Идея - подтягивать все сорцы локально, запускать docs.py тесты для каждого, копировать файлы и коммитить изменения. Написал вспомогательные скрипты для удобства, по идее в три шага можно обновить http файлы для новой фичи.